### PR TITLE
svc: support closing via context

### DIFF
--- a/svc/svc.go
+++ b/svc/svc.go
@@ -30,9 +30,9 @@ type Service interface {
 	Stop() error
 }
 
-// Context interface conteains an optional Context method which a service can implement.
-// when implemented the context.Done() will be used in addition to signal handling to
-// exit a process
+// Context interface contains an optional Context function which a Service can implement.
+// When implemented the context.Done() channel will be used in addition to signal handling
+// to exit a process.
 type Context interface {
 	Context() context.Context
 }

--- a/svc/svc.go
+++ b/svc/svc.go
@@ -1,6 +1,9 @@
 package svc
 
-import "os/signal"
+import (
+	"context"
+	"os/signal"
+)
 
 // Create variable signal.Notify function so we can mock it in tests
 var signalNotify = signal.Notify
@@ -25,6 +28,13 @@ type Service interface {
 	// Stop is called in response to syscall.SIGINT, syscall.SIGTERM, or when a
 	// Windows Service is stopped.
 	Stop() error
+}
+
+// Context interface conteains an optional Context method which a service can implement.
+// when implemented the context.Done() will be used in addition to signal handling to
+// exit a process
+type Context interface {
+	Context() context.Context
 }
 
 // Environment contains information about the environment


### PR DESCRIPTION
In nsqio/nsq#1305 I encountered a situation where I wanted to add additional hooks for exiting a process - but the only exit path for Run() is a `SIGINT`/`SIGTERM`. In order to add new way for applications to signal that the process should exit I am adding a conditional `Context` interface that applications can implement. When implemented `svc` will wait for a `SIGINT`/`SIGTERM` OR for the context to finish.