### PR TITLE
docs: update readme re: go modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,23 @@ Go Windows Service wrapper that plays nice with Linux. Windows tests [here](http
 - Used in Production.
 - Maintained. Issues and Pull Requests will be responded to.
 
-## Install
+## Go Modules
 
-`go get -u github.com/judwhite/go-svc`
+* Please note the `import` path and `go.mod` change from `github.com/judwhite/go-svc/svc` to `github.com/judwhite/go-svc` for `v1.2+`
+* `v1.1.3` and earlier can be imported using the previous import path
+* `v1.2+` code is backwards compatible with previous versions
+
+```nginx no-this-isnt-nginx-but-the-syntax-highlighting-works
+module awesomeProject
+
+go 1.15
+
+require github.com/judwhite/go-svc v1.2.0
+```
+
+```go
+import "github.com/judwhite/go-svc"
+```
 
 ## Example
 


### PR DESCRIPTION
I apologize for any confusion during the brief existence of the v2 tag.

I briefly bumped to v2 due to moving the package up to `go-svc` (repo root) from `go-svc/svc`. Having a `v2.x.x` tag in the repo caused the following issue when testing locally:

```
$ go build
go: errors parsing go.mod:
go.mod:5: require github.com/judwhite/go-svc: version "v2.1.0" invalid: module contains a go.mod file,
so major version must be compatible: should be v0 or v1, not v2
```

I didn't see an immediate way to prevent this issue for new importers other than deleting the v2.0.0 and v2.1.0 tags, which I consider about as distasteful as a force push. On the plus side, users of previous versions should not have been affected.

The v1.2 tag may not have been the ideal solution but hopefully it's a workable one. The code is otherwise compatible with all previous versions.

If you're going to v2 in your own package, see this thread for more info:

https://github.com/golang/go/issues/35732
