### PR TITLE
call service.Context() after service.Init() on windows

### DIFF
--- a/svc_windows.go
+++ b/svc_windows.go
@@ -52,18 +52,11 @@ func Run(service Service, sig ...os.Signal) error {
 		sig = []os.Signal{syscall.SIGINT}
 	}
 
-	var ctx context.Context
-	if s, ok := service.(Context); ok {
-		ctx = s.Context()
-	} else {
-		ctx = context.Background()
-	}
-
 	ws := &windowsService{
 		i:                service,
 		isWindowsService: isWindowsService,
 		signals:          sig,
-		ctx:              ctx,
+		ctx:              context.Background(),
 	}
 
 	if ws.IsWindowsService() {
@@ -77,6 +70,11 @@ func Run(service Service, sig ...os.Signal) error {
 
 	if err = service.Init(ws); err != nil {
 		return err
+	}
+
+	// call service.Context() after service.Init()
+	if s, ok := service.(Context); ok {
+		ws.ctx = s.Context()
 	}
 
 	return ws.run()


### PR DESCRIPTION
service.Context() is called after Init() (and after Start()) on unixes,
so some users did not expect or test with Context() called before Init()

this was noticed in https://github.com/nsqio/nsq/pull/1359
and is still needed along with https://github.com/nsqio/nsq/pull/1361

cc @mreiferson @judwhite